### PR TITLE
Dependabot does not need to track beyond v13

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,24 +16,6 @@ updates:
   allow:
   - dependency-type: "direct"
   versioning-strategy: "increase"
-  target-branch: v15-branch
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: "direct"
-  versioning-strategy: "increase"
-  target-branch: v14-branch
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: "direct"
-  versioning-strategy: "increase"
   target-branch: v13-branch
 - package-ecosystem: composer
   directory: "/"
@@ -44,3 +26,21 @@ updates:
   - dependency-type: "direct"
   versioning-strategy: "increase"
   target-branch: v12-branch
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: "direct"
+  versioning-strategy: "increase"
+  target-branch: v11-branch
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: "direct"
+  versioning-strategy: "increase"
+  target-branch: v10-branch


### PR DESCRIPTION
This reverts commit ff78b419a11269917b697b075df3400a1a8ffafc.